### PR TITLE
*.db-walと*.db-shmを.gitignoreに追加。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ MANIFEST.bak
 *~
 data/*.rrd
 data/*.db
+data/*.db-wal
+data/*.db-shm
 .DS_Store
 MYMETA.*
 


### PR DESCRIPTION
SQLite 3.7.0からWrite-Ahead Loggingに対応しており、_.dbファイルと共に
*.db-walと_.db-shmを生成する場合があるため.gitignoreに追加。
