### PR TITLE
fix ja->en translation miss. "disable" should be 0.

### DIFF
--- a/views/add_complex.tx
+++ b/views/add_complex.tx
@@ -33,8 +33,8 @@
 <label for="">Display sum up value</label>
 <div class="input">
 <select name="sumup" class="small">
-<option value="0">enable</option>
-<option value="1">disable</option>
+<option value="0">disable</option>
+<option value="1">enable</option>
 </select>
 </div>
 </div>


### PR DESCRIPTION
fix a simple miss.
"enable" and "disable" are revrse.

@27e2197

```
-<option value="0">しない</option>
-<option value="1">する</option>
+<option value="0">enable</option>
+<option value="1">disable</option>
```
