### PR TITLE
Make sections collapsible.

### DIFF
--- a/public/js/bootstrap-collapse.js
+++ b/public/js/bootstrap-collapse.js
@@ -1,0 +1,167 @@
+/* =============================================================
+ * bootstrap-collapse.js v2.3.2
+ * http://getbootstrap.com/2.3.2/javascript.html#collapse
+ * =============================================================
+ * Copyright 2013 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ============================================================ */
+
+
+!function ($) {
+
+  "use strict"; // jshint ;_;
+
+
+ /* COLLAPSE PUBLIC CLASS DEFINITION
+  * ================================ */
+
+  var Collapse = function (element, options) {
+    this.$element = $(element)
+    this.options = $.extend({}, $.fn.collapse.defaults, options)
+
+    if (this.options.parent) {
+      this.$parent = $(this.options.parent)
+    }
+
+    this.options.toggle && this.toggle()
+  }
+
+  Collapse.prototype = {
+
+    constructor: Collapse
+
+  , dimension: function () {
+      var hasWidth = this.$element.hasClass('width')
+      return hasWidth ? 'width' : 'height'
+    }
+
+  , show: function () {
+      var dimension
+        , scroll
+        , actives
+        , hasData
+
+      if (this.transitioning || this.$element.hasClass('in')) return
+
+      dimension = this.dimension()
+      scroll = $.camelCase(['scroll', dimension].join('-'))
+      actives = this.$parent && this.$parent.find('> .accordion-group > .in')
+
+      if (actives && actives.length) {
+        hasData = actives.data('collapse')
+        if (hasData && hasData.transitioning) return
+        actives.collapse('hide')
+        hasData || actives.data('collapse', null)
+      }
+
+      this.$element[dimension](0)
+      this.transition('addClass', $.Event('show'), 'shown')
+      $.support.transition && this.$element[dimension](this.$element[0][scroll])
+    }
+
+  , hide: function () {
+      var dimension
+      if (this.transitioning || !this.$element.hasClass('in')) return
+      dimension = this.dimension()
+      this.reset(this.$element[dimension]())
+      this.transition('removeClass', $.Event('hide'), 'hidden')
+      this.$element[dimension](0)
+    }
+
+  , reset: function (size) {
+      var dimension = this.dimension()
+
+      this.$element
+        .removeClass('collapse')
+        [dimension](size || 'auto')
+        [0].offsetWidth
+
+      this.$element[size !== null ? 'addClass' : 'removeClass']('collapse')
+
+      return this
+    }
+
+  , transition: function (method, startEvent, completeEvent) {
+      var that = this
+        , complete = function () {
+            if (startEvent.type == 'show') that.reset()
+            that.transitioning = 0
+            that.$element.trigger(completeEvent)
+          }
+
+      this.$element.trigger(startEvent)
+
+      if (startEvent.isDefaultPrevented()) return
+
+      this.transitioning = 1
+
+      this.$element[method]('in')
+
+      $.support.transition && this.$element.hasClass('collapse') ?
+        this.$element.one($.support.transition.end, complete) :
+        complete()
+    }
+
+  , toggle: function () {
+      this[this.$element.hasClass('in') ? 'hide' : 'show']()
+    }
+
+  }
+
+
+ /* COLLAPSE PLUGIN DEFINITION
+  * ========================== */
+
+  var old = $.fn.collapse
+
+  $.fn.collapse = function (option) {
+    return this.each(function () {
+      var $this = $(this)
+        , data = $this.data('collapse')
+        , options = $.extend({}, $.fn.collapse.defaults, $this.data(), typeof option == 'object' && option)
+      if (!data) $this.data('collapse', (data = new Collapse(this, options)))
+      if (typeof option == 'string') data[option]()
+    })
+  }
+
+  $.fn.collapse.defaults = {
+    toggle: true
+  }
+
+  $.fn.collapse.Constructor = Collapse
+
+
+ /* COLLAPSE NO CONFLICT
+  * ==================== */
+
+  $.fn.collapse.noConflict = function () {
+    $.fn.collapse = old
+    return this
+  }
+
+
+ /* COLLAPSE DATA-API
+  * ================= */
+
+  $(document).on('click.collapse.data-api', '[data-toggle=collapse]', function (e) {
+    var $this = $(this), href
+      , target = $this.attr('data-target')
+        || e.preventDefault()
+        || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
+      , option = $(target).data('collapse') ? 'toggle' : $this.data()
+    $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
+    $(target).collapse(option)
+  })
+
+}(window.jQuery);

--- a/public/js/bootstrap-transition.js
+++ b/public/js/bootstrap-transition.js
@@ -1,0 +1,60 @@
+/* ===================================================
+ * bootstrap-transition.js v2.3.2
+ * http://getbootstrap.com/2.3.2/javascript.html#transitions
+ * ===================================================
+ * Copyright 2013 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================== */
+
+
+!function ($) {
+
+  "use strict"; // jshint ;_;
+
+
+  /* CSS TRANSITION SUPPORT (http://www.modernizr.com/)
+   * ======================================================= */
+
+  $(function () {
+
+    $.support.transition = (function () {
+
+      var transitionEnd = (function () {
+
+        var el = document.createElement('bootstrap')
+          , transEndEventNames = {
+               'WebkitTransition' : 'webkitTransitionEnd'
+            ,  'MozTransition'    : 'transitionend'
+            ,  'OTransition'      : 'oTransitionEnd otransitionend'
+            ,  'transition'       : 'transitionend'
+            }
+          , name
+
+        for (name in transEndEventNames){
+          if (el.style[name] !== undefined) {
+            return transEndEventNames[name]
+          }
+        }
+
+      }())
+
+      return transitionEnd && {
+        end: transitionEnd
+      }
+
+    })()
+
+  })
+
+}(window.jQuery);

--- a/views/base.tx
+++ b/views/base.tx
@@ -115,6 +115,8 @@ GrowthForecast
 <script type="text/javascript" src="<: $c.req.uri_for('/js/jquery-1.10.2.min.js') :>"></script>
 <script type="text/javascript" src="<: $c.req.uri_for('/js/bootstrap-modal.js') :>"></script>
 <script type="text/javascript" src="<: $c.req.uri_for('/js/bootstrap-alert.js') :>"></script>
+<script type="text/javascript" src="<: $c.req.uri_for('/js/bootstrap-transition.js') :>"></script>
+<script type="text/javascript" src="<: $c.req.uri_for('/js/bootstrap-collapse.js') :>"></script>
 <script type="text/javascript">
 $(function(){
   $('form.hxrpost').each(setHxrpost);
@@ -122,6 +124,8 @@ $(function(){
   $('#add-new-row').click(add_new_row);
   $('form#complex-form').each(setTablePreview);
   $('input.color_pallet').each(setColorPallets);
+  $('#link-fold-all').click(fold_all_sections);
+  $('#link-expand-all').click(expand_all_sections);
 });
 
 
@@ -325,6 +329,22 @@ function setColorPallets() {
     pallet.css('left',pos.left+width);
     pallet.toggle();
   });
+}
+
+function fold_all_sections(e) {
+  e.stopPropagation();
+  e.preventDefault();
+
+  $('.service_sections').collapse('hide');
+  return false;
+}
+
+function expand_all_sections(e) {
+  e.stopPropagation();
+  e.preventDefault();
+
+  $('.service_sections').collapse('show');
+  return false;
 }
 
 </script>

--- a/views/index.tx
+++ b/views/index.tx
@@ -6,15 +6,22 @@
 : around page_header -> {
 <h1>
 <a href="<: $c.req.uri_for('/') :>">Home</a><: if $c.args.service_name { :> » <: $c.args.service_name :><: } :>
+<: if ! $c.args.service_name { :>
+<span class="pull-right"><small style="vertical-align: text-middle;font-size: 0.5em"><a id="link-fold-all" href="#">[fold all]</a> / <a id="link-expand-all" href="#">[expand all]</a></small></span>
+<: } :>
 </h1>
 : }
 
 : around content -> {
 : for $services ->  $service {
 <h2>
+<: if ! $c.args.service_name { :>
+<span><small style="vertical-align: text-middle;font-size: 0.5em"><a href="#service_<: $service.name :>" data-toggle="collapse">[+]</a></small></span>
+<: } :>
 <span><a href="<: $c.req.uri_for('/list/'~uri_escape($service.name))  :>"><: $service.name :></a></span>
 <span class="pull-right"><small style="vertical-align: text-middle;font-size: 0.5em"><a href="<: $c.req.uri_for('/add_complex',[service_name=>$service.name]) :>">add complex graph</a></small></span>
 </h2>
+<div id="service_<: $service.name :>" class="service_sections collapse in">
 <table class="table table-striped">
 : for $service.sections -> $section {
 <tr>
@@ -22,6 +29,7 @@
 </tr>
 : }
 </table>
+</div>
 : }
 
 : }


### PR DESCRIPTION
It is difficult to look for target service on sites with many services and many sections. 

With this patch, you can fold sections (and expand sections) on service by clicking `+` beside service name.
Folding / expanding all sections at the same time is also available.

http://gyazo.com/15e98c01ea617292a702c94aac9eb8ce
![Preview](http://gyazo.com/15e98c01ea617292a702c94aac9eb8ce.png)
