### PR TITLE
Make graphs in section page collapsible.

### DIFF
--- a/views/base.tx
+++ b/views/base.tx
@@ -124,8 +124,8 @@ $(function(){
   $('#add-new-row').click(add_new_row);
   $('form#complex-form').each(setTablePreview);
   $('input.color_pallet').each(setColorPallets);
-  $('#link-fold-all').click(fold_all_sections);
-  $('#link-expand-all').click(expand_all_sections);
+  $('#link-fold-all').click(fold_all);
+  $('#link-expand-all').click(expand_all);
 });
 
 
@@ -331,19 +331,21 @@ function setColorPallets() {
   });
 }
 
-function fold_all_sections(e) {
+function fold_all(e) {
   e.stopPropagation();
   e.preventDefault();
 
   $('.service_sections').collapse('hide');
+  $('.section_graphs').collapse('hide');
   return false;
 }
 
-function expand_all_sections(e) {
+function expand_all(e) {
   e.stopPropagation();
   e.preventDefault();
 
   $('.service_sections').collapse('show');
+  $('.section_graphs').collapse('show');
   return false;
 }
 

--- a/views/list.tx
+++ b/views/list.tx
@@ -5,7 +5,8 @@
 : around page_header -> {
 <h1>
 <span><a href="<: $c.req.uri_for('/') :>">Home</a> » <a href="<: $c.req.uri_for('/list/'~uri_escape($c.args.service_name)) :>"><: $c.args.service_name :></a> » <: $c.args.section_name :></span>
-<span class="pull-right"><small style="font-size: 0.4em;vertical-align: text-middle;"><a href="<: $c.req.uri_for('/add_complex',[service_name=>$c.args.service_name,section_name=>$c.args.section_name]) :>">add complex graph</a></small></span>
+<span class="pull-right"><small style="font-size: 0.4em;vertical-align: text-middle;"><a id="link-fold-all" href="#">[fold all]</a> / <a id="link-expand-all" href="#">[expand all]</a> / <a href="<: $c.req.uri_for('/add_complex',[service_name=>$c.args.service_name,section_name=>$c.args.section_name]) :>">add complex graph</a></small></span>
+
 </h1>
 : }
 

--- a/views/view.tx
+++ b/views/view.tx
@@ -1,5 +1,8 @@
 : my $term_arg = $c.req.param('t') ? [ 't', $c.req.param('t') ] : [];
 <h2>
+: if ! $c.args.graph_name {
+<span><small style="vertical-align: text-middle;font-size: 0.5em"><a href="#graph_<: $graph.graph_name :>" data-toggle="collapse">[+]</a></small></span>
+: }
 : if $graph.complex_graph {
 <a href="<: $c.req.uri_for('/view_complex/'~uri_escape($graph.service_name)~'/'~uri_escape($graph.section_name)~'/'~uri_escape($graph.graph_name), $term_arg) :>" data-id="<: $graph.id :>"><: $graph.graph_name :></a>
 : } else {
@@ -19,7 +22,7 @@
 <span class="label">updated_at</span> <: $graph.updated_at :>
 </p>
 
-<div style="margin-bottom: 13px; text-align: center">
+<div id="graph_<: $graph.graph_name :>" class="section_graphs collapse in" style="margin-bottom: 13px; text-align: center">
 : if ! $graph.complex_graph {
   : my $gmodes = ( $graph.gmode == 'both' ) ? ['gauge','subtract'] : ( $graph.gmode == 'gauge') ? ['gauge'] : ['subtract']
   : for $gmodes -> $gmode {


### PR DESCRIPTION
Also collapsible for graphs in section.

Fold (and expand) graphs on service by clicking `+` beside graph name.
Folding / expanding all graphs at the same time is also available.

http://gyazo.com/a27241893a2db1ffd2a1208f73ce02ef
![preview](http://gyazo.com/a27241893a2db1ffd2a1208f73ce02ef.png)
