### PR TITLE
minor typo fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@ $ cpanm -n GrowthForecast
           </div>
       </div>
 
-      <h3>(2) GrowthForecastの起動</h3>
+      <h3>(3) GrowthForecastの起動</h3>
 
         <div class="row">
           <div class="span4">


### PR DESCRIPTION
Fixing a minor typo. (2) -> (3) in one of the section headers.
