### PR TITLE
Fix graph collapsing in single graph page.

### DIFF
--- a/views/view.tx
+++ b/views/view.tx
@@ -28,7 +28,7 @@
   <span class="label label-default">updated_at</span> <: $graph.updated_at :>
 </p>
 
-<div id="graph_<: if $graph.complex_graph{ :>complex_<: } :><: $graph.id :>" class="section_graphs panel-collapse in">
+<div id="graph_<: if $graph.complex_graph{ :>complex_<: } :><: $graph.id :>" class="<: if ! $c.args.graph_name { :>section_graphs <: } :>panel-collapse in">
 <table style="margin: 0 auto 10px">
 : if ! $graph.complex_graph {
   : my $gmodes = ( $graph.gmode == 'both' ) ? ['gauge','subtract'] : ( $graph.gmode == 'gauge') ? ['gauge'] : ['subtract']


### PR DESCRIPTION
Reproduction for this bug:

Step 1) access http://.../list/service-a/section-1
Step 2) fold graph x (memorized into local storage)
Step 3) access http://.../view_graph/service-a/section-1/graph-x
Step 4) graph x is hidden (is automatically folded on page load and I cannot collapse it)
