### PR TITLE
--disable-subtract

### DIFF
--- a/README
+++ b/README
@@ -53,6 +53,9 @@ OPTIONS
     --disable-1min-metrics
         don't generate 1min rrddata and graph Default is "1" (enabled)
 
+    --disable-subtract
+        Disable gmode `subtract`. Default is "1" (enabled)
+
     --enable-float-number
         Store numbers of graph data as float rather than integer. Default is
         "0" (disabled)
@@ -110,7 +113,7 @@ MYSQL Setting
     Give USERNAME and PASSWORD to GrowthForecast by environment value
 
       $ MYSQL_USER=www MYSQL_PASSWORD=foobar growthforecast.pl \\
-          --data-dir /home/user/growthforeacst \\
+          --data-dir /home/user/growthforecast \\
           -with-mysql dbi:mysql:growthforecast;hostname=localhost
 
     AUTHOR Masahiro Nagano <kazeburo {at} gmail.com>

--- a/eg/alter_for_float_number.pl
+++ b/eg/alter_for_float_number.pl
@@ -19,6 +19,7 @@ Getopt::Long::Configure ("no_ignore_case");
 GetOptions(
     'data-dir=s' => \my $data_dir,
     'with-mysql=s' => \my $mysql,
+    'disable-subtract' => \my $disable_subtract,
     "h|help" => \my $help,
 );
 
@@ -44,12 +45,24 @@ else {
 
 my $enable_float_number = 1;
 my $data = $mysql
-    ? GrowthForecast::Data::MySQL->new($mysql, $enable_float_number)
-    : GrowthForecast::Data->new($data_dir, $enable_float_number);
+    ? GrowthForecast::Data::MySQL->new($mysql, $enable_float_number, $disable_subtract)
+    : GrowthForecast::Data->new($data_dir, $enable_float_number, $disable_subtract);
 
 if ($mysql) {
     my $number_type = $data->number_type;
     my $complex_number_type = $data->complex_number_type;
+    unless ( $disable_subtract ) {
+        $data->dbh->query(<<EOF);
+ALTER TABLE prev_graphs
+    MODIFY COLUMN number   $number_type NOT NULL DEFAULT 0,
+    MODIFY COLUMN subtract $number_type
+EOF
+        $data->dbh->query(<<EOF);
+ALTER TABLE prev_short_graphs
+    MODIFY COLUMN number   $number_type NOT NULL DEFAULT 0,
+    MODIFY COLUMN subtract $number_type
+EOF
+    }
     $data->dbh->query(<<EOF);
 ALTER TABLE graphs
     MODIFY COLUMN number  $number_type NOT NULL DEFAULT 0,
@@ -59,34 +72,28 @@ ALTER TABLE graphs
     MODIFY COLUMN sllimit $number_type NOT NULL DEFAULT 0
 EOF
     $data->dbh->query(<<EOF);
-ALTER TABLE prev_graphs
-    MODIFY COLUMN number   $number_type NOT NULL DEFAULT 0,
-    MODIFY COLUMN subtract $number_type
-EOF
-    $data->dbh->query(<<EOF);
-ALTER TABLE prev_short_graphs
-    MODIFY COLUMN number   $number_type NOT NULL DEFAULT 0,
-    MODIFY COLUMN subtract $number_type
-EOF
-    $data->dbh->query(<<EOF);
 ALTER TABLE complex_graphs
     MODIFY COLUMN number   $complex_number_type UNSIGNED NOT NULL DEFAULT 0
 EOF
 }
 else {
     # NOTE: sqlite does not support `ALTER TABLE MODIFY COLUMN`.
+    unless ( $disable_subtract ) {
+        $data->dbh->query('ALTER TABLE prev_graphs RENAME TO tmp_prev_graphs');
+        $data->dbh->query('ALTER TABLE prev_short_graphs RENAME TO tmp_prev_short_graphs');
+    }
     $data->dbh->query('ALTER TABLE graphs RENAME TO tmp_graphs');
-    $data->dbh->query('ALTER TABLE prev_graphs RENAME TO tmp_prev_graphs');
-    $data->dbh->query('ALTER TABLE prev_short_graphs RENAME TO tmp_prev_short_graphs');
     $data->dbh->query('ALTER TABLE complex_graphs RENAME TO tmp_complex_graphs');
     undef($data->{dbh}); # To re-create tables by calling on_connect callback
+    unless ( $disable_subtract ) {
+        $data->dbh->query('INSERT INTO prev_graphs SELECT * from tmp_prev_graphs');
+        $data->dbh->query('INSERT INTO prev_short_graphs SELECT * from tmp_prev_short_graphs');
+        $data->dbh->query('DROP TABLE tmp_prev_graphs');
+        $data->dbh->query('DROP TABLE tmp_prev_short_graphs');
+    }
     $data->dbh->query('INSERT INTO graphs SELECT * from tmp_graphs');
-    $data->dbh->query('INSERT INTO prev_graphs SELECT * from tmp_prev_graphs');
-    $data->dbh->query('INSERT INTO prev_short_graphs SELECT * from tmp_prev_short_graphs');
-    $data->dbh->query('INSERT INTO complex_graphs SELECT * from tmp_complex_graphs');
     $data->dbh->query('DROP TABLE tmp_graphs');
-    $data->dbh->query('DROP TABLE tmp_prev_graphs');
-    $data->dbh->query('DROP TABLE tmp_prev_short_graphs');
+    $data->dbh->query('INSERT INTO complex_graphs SELECT * from tmp_complex_graphs');
     $data->dbh->query('DROP TABLE tmp_complex_graphs');
 }
 
@@ -123,6 +130,10 @@ $ alter_for_float_number.pl
 
  $ MYSQL_USER=www MYSQL_PASSWORD=foobar alter_for_float_number.pl \\
      --with-mysql dbi:mysql:growthforecast;hostname=localhost
+
+=item --disable-subtract
+
+ Specify if your GrowthForecast is using --disable-subtract option.
 
 =item -h --help
 

--- a/eg/benchmark_rrd.pl
+++ b/eg/benchmark_rrd.pl
@@ -35,6 +35,7 @@ GetOptions(
     's|short'      => \my $short,
     'm|md5'        => \my $md5,
     'd|daemon=s'   => \my $rrdcached,
+    'disable-subtract' => \my $disable_subtract,
     "h|help"       => \my $help,
 );
 
@@ -57,6 +58,7 @@ my $rrd = GrowthForecast::RRD->new(
     data_dir => $data_dir,
     root_dir => $root_dir,
     rrdcached => $rrdcached,
+    disable_subtract => $disable_subtract,
 );
 
 my $md5_func;
@@ -79,8 +81,9 @@ sub bench(&) {
             $data->{number} = int(rand($number));
             $code->($data);
         }
-        printf("%0.3f to %s %d %sgraphs%s.\n", Time::HiRes::time - $start_time,
+        printf("%0.3f to %s %d %sgraphs%s%s.\n", Time::HiRes::time - $start_time,
             $create ? 'create' : 'update' , $number, $short ? 'short ' : '',
+            $disable_subtract ? ' without subtract DS' : '',
             $rrdcached ? ' with rrdcached' : '');
     }
 }
@@ -147,6 +150,10 @@ $ benchmark_rrd.pl
 =item -s --short
 
  Benchmark the 1min rrd data. Default: false, which means benchmark the normal rrd
+
+=item --disable-subtract
+
+ Benchmark without creating subtract datasource on RRD file (GrowthForecast creates sub DS in addition to num DS as default)
 
 =item -m --md5
 

--- a/growthforecast.pl
+++ b/growthforecast.pl
@@ -35,6 +35,7 @@ GetOptions(
     'front-proxy=s' => \@front_proxy,
     'allow-from=s' => \@allow_from,
     'disable-1min-metrics' => \my $disable_short,
+    'disable-subtract' => \my $disable_subtract,
     'enable-float-number' => \my $enable_float_number,
     'with-mysql=s' => \my $mysql,
     'data-dir=s' => \my $data_dir,
@@ -99,6 +100,7 @@ $proclet->service(
             mysql => $mysql,
             float_number => $enable_float_number,
             rrdcached => $rrdcached,
+            disable_subtract => $disable_subtract,
         );
         $worker->run('short');        
     }
@@ -113,6 +115,7 @@ $proclet->service(
             mysql => $mysql,
             float_number => $enable_float_number,
             rrdcached => $rrdcached,
+            disable_subtract => $disable_subtract,
         );
         $worker->run;
     }
@@ -128,6 +131,7 @@ $proclet->service(
             mysql => $mysql,
             float_number => $enable_float_number,
             rrdcached => $rrdcached,
+            disable_subtract => $disable_subtract,
         );
         my $app = builder {
             enable 'Lint';
@@ -274,6 +278,10 @@ Default is empty (allow access from any remote ip address)
 
 don't generate 1min rrddata and graph
 Default is "1" (enabled) 
+
+=item --disable-subtract
+
+Disable gmode `subtract`. Default is "1" (enabled)
 
 =item --enable-float-number
 

--- a/lib/GrowthForecast/Data/MySQL.pm
+++ b/lib/GrowthForecast/Data/MySQL.pm
@@ -10,7 +10,8 @@ sub new {
     my $class = shift;
     my $mysql = shift;
     my $float_number = shift;
-    bless { mysql => $mysql, float_number => $float_number }, $class;
+    my $disable_subtract = shift;
+    bless { mysql => $mysql, float_number => $float_number, disable_subtract => $disable_subtract }, $class;
 }
 
 sub number_type {
@@ -56,7 +57,8 @@ CREATE TABLE IF NOT EXISTS graphs (
 )  ENGINE=InnoDB DEFAULT CHARSET=utf8
 EOF
 
-        $dbh->do(<<EOF);
+        unless ( $self->{disable_subtract} ) {
+            $dbh->do(<<EOF);
 CREATE TABLE IF NOT EXISTS prev_graphs (
     graph_id     INT UNSIGNED NOT NULL,
     number       $number_type NOT NULL DEFAULT 0,
@@ -66,7 +68,7 @@ CREATE TABLE IF NOT EXISTS prev_graphs (
 )  ENGINE=InnoDB DEFAULT CHARSET=utf8
 EOF
 
-        $dbh->do(<<EOF);
+            $dbh->do(<<EOF);
 CREATE TABLE IF NOT EXISTS prev_short_graphs (
     graph_id     INT UNSIGNED NOT NULL,
     number       $number_type NOT NULL DEFAULT 0,
@@ -75,7 +77,7 @@ CREATE TABLE IF NOT EXISTS prev_short_graphs (
     PRIMARY KEY  (graph_id)
 )  ENGINE=InnoDB DEFAULT CHARSET=utf8
 EOF
-
+        }
 
         $dbh->do(<<EOF);
 CREATE TABLE IF NOT EXISTS complex_graphs (

--- a/views/add_complex.tx
+++ b/views/add_complex.tx
@@ -106,7 +106,9 @@
 </select></td>
 <td style="text-align: center"><select name="gmode-1" class="form-control">
 <option value="gauge">Gauge</option>
+: if !$disable_subtract {
 <option value="subtract">Subtract</option>
+: }
 </select></td>
 </tr>
 </table>
@@ -141,7 +143,9 @@
 </select></td>
 <td style="text-align: center"><select name="gmode-add" id="gmode-add" class="form-control">
 <option value="gauge">Gauge</option>
+: if !$disable_subtract {
 <option value="subtract">Subtract</option>
+: }
 </select></td>
 <td style="text-align:center;"><select name="stack-add" id="stack-add" class="form-control">
 <option value="1">enable</option>

--- a/views/edit.tx
+++ b/views/edit.tx
@@ -71,8 +71,10 @@
   <div class="col-sm-4">
     <select name="gmode" class="form-control">
     <option value="gauge">Gauge</option>
+: if !$disable_subtract {
     <option value="subtract">Subtract</option>
     <option value="both">Both</option>
+: }
     </select>
    </div>
 </div>

--- a/views/edit_complex.tx
+++ b/views/edit_complex.tx
@@ -106,7 +106,9 @@
 </select></td>
 <td style="text-align: center"><select name="gmode-1" class="form-control">
 <option value="gauge">Gauge</option>
+: if !$disable_subtract {
 <option value="subtract">Subtract</option>
+: }
 </select></td>
 </tr>
 </table>
@@ -143,7 +145,9 @@
 </select></td>
 <td style="text-align: center"><select name="gmode-add" id="gmode-add" class="form-control">
 <option value="gauge">Gauge</option>
+: if !$disable_subtract {
 <option value="subtract">Subtract</option>
+: }
 </select></td>
 <td style="text-align:center;"><select name="stack-add" id="stack-add" class="form-control">
 <option value="1">enable</option>
@@ -154,7 +158,7 @@
 </tr>
 
 : my $type_hash = { 'AREA' => 'AREA', 'LINE1' => 'LINE', 'LINE2' => 'LINE(Bold)' }
-: my $gmode_hash = { 'gauge' => 'Gauge', 'subtract' => 'Subtract' }
+: my $gmode_hash = $disable_subtract ? { 'gauge' => 'Gauge' } : { 'gauge' => 'Gauge', 'subtract' => 'Subtract' }
 : my $stack_hash = { '1' => 'enable', 'subtract' => 'disable' }
 : for $c.stash.complex.data_rows ->  $row {
 <tr class="can-table-order">


### PR DESCRIPTION
Added `--disable-subtract` option. 

By disabling `subtract` functionality, we can improve the performance of the GrowthForecast worker drastically because
1. We can avoid N+1 queries issued at https://github.com/kazeburo/GrowthForecast/blob/c3bc89dd2d2f3ab01dbfd5a181e931cd15364761/lib/GrowthForecast/Worker.pm#L94-L105
2. We can avoid to have `sub` DS in RRD files, which results in reducing disk size and disk access to half
   https://github.com/kazeburo/GrowthForecast/blob/c3bc89dd2d2f3ab01dbfd5a181e931cd15364761/lib/GrowthForecast/RRD.pm#L33

In my environments, I achieved following performance improvement to update 60,000 graphs

```
Before: 50 sec
After: 10 sec
```

I also prepared --disable-subtract option for `eg/alter_for_float_number.pl` and `eg/benchmark_rrd.pl`. 

Please note that I took care of that users can upgrade to use --disable-subtract without deleting RRD files and databases.

FYI: ?w=1 should be useful to see diff because many diffs are just indentation diffs. https://github.com/kazeburo/GrowthForecast/pull/50/files?w=1

EDIT: Because RRD itself has DERIVE mode which is actually same with subtract, we would be able to remove gmode (gauge or subtract or both) to make it simple in the future.
