### PR TITLE
Fix exported json graphs' keys

### DIFF
--- a/lib/GrowthForecast/RRD.pm
+++ b/lib/GrowthForecast/RRD.pm
@@ -386,7 +386,8 @@ sub graph {
             $graphv[0]->[$i+2],
             $graphv[0]->[$i+3]
         );
-        $graph_args{$data->{graph_name}} = [$current, $average, $max, $min];
+        my $graph_path = join('/', $data->{service_name}, $data->{section_name}, $data->{graph_name});
+        $graph_args{$graph_path} = [$current, $average, $max, $min];
         $i = $i + 4;
     }
     if ( $args->{sumup} ) {


### PR DESCRIPTION
- keys of graph_name are duplicated for different service/section graphs
- graph keys should be unique
  - duplicated key name are overwritten, and it make json broken on `/summary/:spec` api
- full-path service/section/graph_name keys are unique
  - this fix breaks compatibility of exported json keys
