### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -114,7 +114,7 @@ MYSQL Setting
 
       $ MYSQL_USER=www MYSQL_PASSWORD=foobar growthforecast.pl \\
           --data-dir /home/user/growthforeacst \\
-          -with-mysql dbi:mysql:growthforecast;hostname=localhost
+          --with-mysql "dbi:mysql:growthforecast;hostname=localhost"
 
     AUTHOR Masahiro Nagano <kazeburo {at} gmail.com>
 


### PR DESCRIPTION
--with-mysql dbi:mysql:growthforecast;hostname=localhost
上記の形だとオプションが;以降を捨ててしまいgrowthforecast.plの54行目 $mysqlの存在確認をしている所でprint "$mysql \n";を実行すると
dbi:mysql:growthforecast 
と扱わてしまいhostが常にlocalhostになってしまう。ダブルクオーテーションで囲むと意図した通りhostnameまでオプションで扱われた。
