### PR TITLE
[PROPOSE] API timestamp support

### DIFF
--- a/lib/GrowthForecast/Data/MySQL.pm
+++ b/lib/GrowthForecast/Data/MySQL.pm
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS graphs (
     meta         TEXT,
     created_at   INT UNSIGNED NOT NULL,
     updated_at   INT UNSIGNED NOT NULL,
+    timestamp    INT UNSIGNED DEFAULT NULL,
     PRIMARY KEY (id),
     UNIQUE  (service_name, section_name, graph_name)
 )  ENGINE=InnoDB DEFAULT CHARSET=utf8
@@ -117,6 +118,18 @@ EOF
             if ( ! exists $graphs_columns{dashes} ) {
                 infof("add new column 'dashes'");
                 $dbh->do(q{ALTER TABLE vrules ADD dashes VARCHAR(255) NOT NULL DEFAULT ''});
+            }
+        }
+
+        # timestamp
+        {
+            my $sth = $dbh->column_info(undef,undef,"graphs",undef);
+            my $columns = $sth->fetchall_arrayref(+{ COLUMN_NAME => 1 });
+            my %graphs_columns;
+            $graphs_columns{$_->{COLUMN_NAME}} = 1 for @$columns;
+            if ( ! exists $graphs_columns{timestamp} ) {
+                infof("add new column 'timestamp'");
+                $dbh->do(q{ALTER TABLE graphs ADD timestamp INT UNSIGNED DEFAULT NULL});
             }
         }
 

--- a/lib/GrowthForecast/RRD.pm
+++ b/lib/GrowthForecast/RRD.pm
@@ -22,8 +22,10 @@ sub path_param {
     my $data = shift;
 
     my $dst = $data->{mode} eq 'derive' ? 'DERIVE' : 'GAUGE';
+    my $timestamp = $data->{timestamp} || time;
 
     my @param = (
+        '--start', $timestamp - 10, # -10 as rrdcreate's default does (now - 10s)
         '--step', '300',
         "DS:num:${dst}:600:U:U",
         'RRA:AVERAGE:0.5:1:1440',  #5分, 5日
@@ -64,8 +66,10 @@ sub path_short_param {
     my $data = shift;
 
     my $dst = $data->{mode} eq 'derive' ? 'DERIVE' : 'GAUGE';
+    my $timestamp = $data->{timestamp} || time;
 
     my @param = (
+        '--start', $timestamp - 10, # -10 as rrdcreate's default does (now - 10s)
         '--step', '60',
         "DS:num:${dst}:120:U:U",
         'RRA:AVERAGE:0.5:1:4800',  #1分, 3日(80時間)
@@ -100,16 +104,17 @@ sub update_param {
     my $data = shift;
 
     my @param;
+    my $timestamp = $data->{timestamp} || 'N';
     if ( $self->{disable_subtract} ) {
         @param = (
             '-t', 'num',
-            '--', join(':','N',$data->{number}),
+            '--', join(':',$timestamp,$data->{number}),
         );
     }
     else {
         @param = (
             '-t', 'num:sub',
-            '--', join(':','N',$data->{number},$data->{subtract}),
+            '--', join(':',$timestamp,$data->{number},$data->{subtract}),
         );
     }
     if ( $self->{rrdcached} ) {
@@ -129,7 +134,14 @@ sub update {
         my @param = $self->update_param($data);
         RRDs::update($file, @param);
         my $ERR=RRDs::error;
-        die $ERR if $ERR;
+        if ( $ERR ) {
+            if ( $ERR =~ /illegal attempt to update using time.*when last update time is.*minimum one second step/ ) {
+                debugf "update rrdfile failed: $ERR";
+            }
+            else {
+                die $ERR;
+            }
+        }
     };
     die "udpate rrdfile failed: $@" if $@;
 }
@@ -139,16 +151,17 @@ sub update_short_param {
     my $data = shift;
 
     my @param;
+    my $timestamp = $data->{timestamp} || 'N';
     if ( $self->{disable_subtract} ) {
         @param = (
             '-t', 'num',
-            '--', join(':','N',$data->{number}),
+            '--', join(':',$timestamp,$data->{number}),
         );
     }
     else {
         @param = (
             '-t', 'num:sub',
-            '--', join(':','N',$data->{number},$data->{subtract_short}),
+            '--', join(':',$timestamp,$data->{number},$data->{subtract_short}),
         );
     }
     if ( $self->{rrdcached} ) {
@@ -168,7 +181,14 @@ sub update_short {
         my @param = $self->update_short_param($data);
         RRDs::update($file, @param);
         my $ERR=RRDs::error;
-        die $ERR if $ERR;
+        if ( $ERR ) {
+            if ( $ERR =~ /illegal attempt to update using time.*when last update time is.*minimum one second step/ ) {
+                debugf "update rrdfile failed: $ERR";
+            }
+            else {
+                die $ERR;
+            }
+        }
     };
     die "udpate rrdfile failed: $@" if $@;
 }

--- a/lib/GrowthForecast/Web.pm
+++ b/lib/GrowthForecast/Web.pm
@@ -891,6 +891,17 @@ post '/api/:service_name/:section_name/:graph_name' => sub {
                 [sub{ length($_[1]) == 0 || $_[1] =~ m!^#[0-9A-F]{6,8}$!i }, 'invalid color format'],
             ],
         },
+        'timestamp' => {
+            default => undef,
+            rule => [
+                # The timestamp is UNIX epoch time
+                # The timestamp of rrdcreate must be larger than 315360000 because of its bug.
+                # cf. https://lists.oetiker.ch/pipermail/rrd-users/2008-January.txt
+                # 10 is because I subtract 10 from the timestamp for rrdcreate as rrdcreate's default does (now - 10s).
+                # cf. http://oss.oetiker.ch/rrdtool/doc/rrdcreate.en.html
+                [sub{ !defined($_[1]) || ($_[1] =~ m!^\-?[\d]+$! && $_[1] > 315360010) }, '"timestamp" must be a INT number and greater than 315360010"']
+            ],
+        },
     ]);
 
     if ( $result->has_error ) {
@@ -907,13 +918,14 @@ post '/api/:service_name/:section_name/:graph_name' => sub {
         $row = $self->data->update(
             $c->args->{service_name}, $c->args->{section_name}, $c->args->{graph_name},
             $result->valid('number'), $result->valid('mode'), $result->valid('color'),
-            $result->valid('description')
+            $result->valid('timestamp'),
         );
     };
     if ( $@ ) {
-        die sprintf "Error:%s %s/%s/%s => %s,%s,%s", 
+        die sprintf "Error:%s %s/%s/%s => %s,%s,%s,%s",
             $@, $c->args->{service_name}, $c->args->{section_name}, $c->args->{graph_name},
-                $result->valid('number'), $result->valid('mode'), $result->valid('color');
+                $result->valid('number'), $result->valid('mode'), $result->valid('color'),
+                $result->valid('timestamp');
     }
     
     my @descriptions = $c->req->param('description');


### PR DESCRIPTION
This pull request is to make it possible to specify the timestamp on API like:

``` bash
curl -d 'number=10&timestamp=1400068922' 'http://localhost:5125/api/a/b/c'
```

although the default behavior does the rrdupdate with the current time. 

I especially want this feature to use GrowthForecast with [Norikra](http://norikra.github.io/). Norikra has a feature called [externally timed batch window](http://norikra.github.io/query.html) which sees the time field of event messages to aggregate. However, because current GrowthForecast does not support time field, I can not utilize the function of Norikra. 

Note that `rrdupdate` itself has a limitation that it does not accept `timestamp` which is newer than the last update time. I wrote detailed descriptions about how to implement this feature considering of the limitation at https://gist.github.com/sonots/3ddba0756d945c59ce5e (Japanese). This pull request implements the (1) way written on it. 
