### PR TITLE
Fix a link to JSON from list of graphs

### DIFF
--- a/views/view.tx
+++ b/views/view.tx
@@ -21,8 +21,9 @@
   <span class="label label-warning">Complex Graph</span>
   <a class="label label-info" style="cursor: pointer" href="<: $c.req.uri_for('/xport/'~$graph.complex_graph, [t=>$term,sumup=>$graph.sumup]) :>"><span class="glyphicon glyphicon-share"></span> JSON</a>
   : } else {
+    : my $term = $c.req.param('t');
   <a class="label label-success" style="cursor: pointer" href="<: $c.req.uri_for('/edit/'~uri_escape($graph.service_name)~'/'~uri_escape($graph.section_name)~'/'~uri_escape($graph.graph_name)) :>"><span class="glyphicon glyphicon-wrench"></span> Setting</a>
-  <a class="label label-info" style="cursor: pointer" href="<: $c.req.uri_for('/xport/'~uri_escape($graph.service_name)~'/'~uri_escape($graph.section_name)~'/'~uri_escape($graph.graph_name)) :>"><span class="glyphicon glyphicon-share"></span> JSON</a>
+  <a class="label label-info" style="cursor: pointer" href="<: $c.req.uri_for('/xport/'~uri_escape($graph.service_name)~'/'~uri_escape($graph.section_name)~'/'~uri_escape($graph.graph_name), [t=>$term]) :>"><span class="glyphicon glyphicon-share"></span> JSON</a>
   <span class="label label-default">current</span> <: $graph.number | format_number :>
   <span class="label label-default">mode</span> <: $graph.mode :>
   : }


### PR DESCRIPTION
JSON link which is at graph list doesn't take
care terms when not complex graph.
So change it to handle them.

![https://i.gyazo.com/6a7647f9288426d803d73a26f57e728a.png](https://i.gyazo.com/6a7647f9288426d803d73a26f57e728a.png)