### PR TITLE
fix syntax of version check

### DIFF
--- a/growthforecast.pl
+++ b/growthforecast.pl
@@ -16,7 +16,7 @@ use GrowthForecast::Web;
 use GrowthForecast::Worker;
 use IO::Socket::UNIX;
 use Proclet;
-use Starlet '0.21';
+use Starlet 0.21;
 use File::ShareDir qw/dist_dir/;
 use Cwd;
 use File::Path qw/mkpath/;


### PR DESCRIPTION
Quoting a version in a use line will cause it to be treated as an import argument rather than a version check. If the module is using Exporter, this will cause the version to be checked, but otherwise will be ignored or result in an error.